### PR TITLE
Fix trade with WAVAX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@traderjoe-xyz/sdk-v2",
   "license": "MIT",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/playground/src/swapAmountIn.js
+++ b/playground/src/swapAmountIn.js
@@ -66,6 +66,8 @@ const swapAmountIn = async () => {
     allRoutes,
     amountIn,
     outputToken,
+    false,
+    false,
     provider,
     chainId
   ) // console.log('trades', trades.map(el=>el.toLog()))

--- a/playground/src/swapAmountOut.js
+++ b/playground/src/swapAmountOut.js
@@ -65,6 +65,8 @@ const swapAmountOut = async () => {
     allRoutes,
     amountOut,
     inputToken,
+    false,
+    false,
     provider,
     chainId
   )

--- a/src/v2entities/trade.test.ts
+++ b/src/v2entities/trade.test.ts
@@ -1,5 +1,12 @@
 import { ethers } from 'ethers'
-import { ChainId, WAVAX, Token, TokenAmount, JSBI } from '@traderjoe-xyz/sdk'
+import {
+  ChainId,
+  WAVAX as _WAVAX,
+  Token,
+  TokenAmount,
+  JSBI,
+  Percent
+} from '@traderjoe-xyz/sdk'
 import { parseUnits } from '@ethersproject/units'
 import { PairV2 } from './pair'
 import { RouteV2 } from './route'
@@ -25,12 +32,12 @@ describe('TradeV2 entity', () => {
     'USDT.e',
     'Tether USD'
   )
-  const AVAX = WAVAX[ChainId.FUJI]
-  const BASES = [AVAX, USDC, USDT]
+  const WAVAX = _WAVAX[ChainId.FUJI]
+  const BASES = [WAVAX, USDC, USDT]
 
   // init input / output
   const inputToken = USDC
-  const outputToken = AVAX
+  const outputToken = WAVAX
 
   // token pairs
   const allTokenPairs = PairV2.createAllTokenPairs(
@@ -74,6 +81,8 @@ describe('TradeV2 entity', () => {
         allRoutes,
         amountIn,
         outputToken,
+        false,
+        false,
         PROVIDER,
         CHAIN_ID
       )
@@ -87,6 +96,8 @@ describe('TradeV2 entity', () => {
         allRoutes,
         amountOut,
         inputToken,
+        false,
+        false,
         PROVIDER,
         CHAIN_ID
       )
@@ -100,6 +111,8 @@ describe('TradeV2 entity', () => {
         allRoutes,
         amountIn,
         outputToken,
+        false,
+        false,
         PROVIDER,
         CHAIN_ID
       )
@@ -127,6 +140,8 @@ describe('TradeV2 entity', () => {
         allRoutes,
         amountOut,
         inputToken,
+        false,
+        false,
         PROVIDER,
         CHAIN_ID
       )
@@ -156,6 +171,8 @@ describe('TradeV2 entity', () => {
         allRoutes,
         amountIn,
         outputToken,
+        false,
+        false,
         PROVIDER,
         CHAIN_ID
       )
@@ -164,6 +181,8 @@ describe('TradeV2 entity', () => {
         allRoutes,
         amountOut,
         inputToken,
+        false,
+        false,
         PROVIDER,
         CHAIN_ID
       )
@@ -188,6 +207,56 @@ describe('TradeV2 entity', () => {
           expect(token.address).toBe(otherRouteToken.address)
         })
       }
+    })
+  })
+  describe('TradeV2.swapCallParameters()', () => {
+    it('generates swapExactTokensForAVAX method', async () => {
+      const isAvaxOut = true
+
+      const trades = await TradeV2.getTradesExactIn(
+        allRoutes,
+        amountIn,
+        outputToken,
+        false,
+        isAvaxOut,
+        PROVIDER,
+        CHAIN_ID
+      )
+
+      const bestTrade = TradeV2.chooseBestTrade(trades as TradeV2[], true)
+
+      const options = {
+        allowedSlippage: new Percent(JSBI.BigInt(50), JSBI.BigInt(10000)),
+        ttl: 1000,
+        recipient: '0x0000000000000000000000000000000000000000'
+      }
+      expect(bestTrade?.swapCallParameters(options)?.methodName).toBe(
+        'swapExactTokensForAVAX'
+      )
+    })
+    it('generates swapExactTokensForTokens method', async () => {
+      const isAvaxOut = false
+
+      const trades = await TradeV2.getTradesExactIn(
+        allRoutes,
+        amountIn,
+        outputToken,
+        false,
+        isAvaxOut,
+        PROVIDER,
+        CHAIN_ID
+      )
+
+      const bestTrade = TradeV2.chooseBestTrade(trades as TradeV2[], true)
+
+      const options = {
+        allowedSlippage: new Percent(JSBI.BigInt(50), JSBI.BigInt(10000)),
+        ttl: 1000,
+        recipient: '0x0000000000000000000000000000000000000000'
+      }
+      expect(bestTrade?.swapCallParameters(options)?.methodName).toBe(
+        'swapExactTokensForTokens'
+      )
     })
   })
 })

--- a/src/v2entities/trade.ts
+++ b/src/v2entities/trade.ts
@@ -326,6 +326,8 @@ export class TradeV2 {
    * @param {RouteV2[]} routes
    * @param {TokenAmount} tokenAmountIn
    * @param {Token} tokenOut
+   * @param {boolean} isAvaxIn
+   * @param {boolean} isAvaxOut
    * @param {Provider | Web3Provider | any} provider
    * @param {ChainId} chainId
    * @returns {TradeV2[]}
@@ -334,14 +336,19 @@ export class TradeV2 {
     routes: RouteV2[],
     tokenAmountIn: TokenAmount,
     tokenOut: Token,
+    isAvaxIn: boolean,
+    isAvaxOut: boolean,
     provider: Provider | Web3Provider | any,
     chainId: ChainId
   ): Promise<Array<TradeV2 | undefined>> {
     const isExactIn = true
-    const isAvaxIn = tokenAmountIn.token.address === WAVAX[chainId].address
-    const isAvaxOut = tokenOut.address === WAVAX[chainId].address
 
-    if (isAvaxIn && isAvaxOut) {
+    // handle wavax<->avax wrap swaps
+    const isWrapSwap =
+      (isAvaxIn && tokenOut.address === WAVAX[chainId].address) ||
+      (isAvaxOut && tokenAmountIn.token.address === WAVAX[chainId].address)
+
+    if (isWrapSwap) {
       return []
     }
 
@@ -391,6 +398,8 @@ export class TradeV2 {
    * @param {RouteV2[]} routes
    * @param {TokenAmount} tokenAmountOut
    * @param {Token} tokenIn
+   * @param {boolean} isAvaxIn
+   * @param {boolean} isAvaxOut
    * @param {Provider | Web3Provider | any} provider
    * @param {ChainId} chainId
    * @returns {TradeV2[]}
@@ -399,14 +408,19 @@ export class TradeV2 {
     routes: RouteV2[],
     tokenAmountOut: TokenAmount,
     tokenIn: Token,
+    isAvaxIn: boolean,
+    isAvaxOut: boolean,
     provider: Provider | Web3Provider | any,
     chainId: ChainId
   ): Promise<Array<TradeV2 | undefined>> {
     const isExactIn = false
-    const isAvaxIn = tokenIn.address === WAVAX[chainId].address
-    const isAvaxOut = tokenAmountOut.token.address === WAVAX[chainId].address
 
-    if (isAvaxIn && isAvaxOut) {
+    // handle wavax<->avax wrap swaps
+    const isWrapSwap =
+      (isAvaxIn && tokenAmountOut.token.address === WAVAX[chainId].address) ||
+      (isAvaxOut && tokenIn.address === WAVAX[chainId].address)
+
+    if (isWrapSwap) {
       return []
     }
 


### PR DESCRIPTION
This PR fixes the issue that `TradeV2.getTradesExactIn()` and `TradeV2.getTradesExactOut()` functions were not differentiating WAVAX and AVAX. To make this differentiation we pass-in additional parameters`isAvaxIn` and `isAvaxOut`. 